### PR TITLE
Idle the ts while the display is off but the device is not locked

### DIFF
--- a/etc/dbus-scripts.d/suspend-ts
+++ b/etc/dbus-scripts.d/suspend-ts
@@ -1,0 +1,1 @@
+/usr/share/droid4-powermanagement/display-state-pm.sh * * com.nokia.mce.signal display_status_ind *

--- a/scripts/openrc/droid4-pm
+++ b/scripts/openrc/droid4-pm
@@ -75,7 +75,6 @@ check_module_blacklist() {
 	warn_if_module_loaded omap_hdq "Seems to poll devices, blacklist?"
 	warn_if_module_loaded hci_uart "Blocks uart4 idle oopses on rmmod, blacklist?"
 	warn_if_module_loaded phy-cpcap-usb "Consumes extra 10mW, used by debug UART, unload?"
-	warn_if_module_loaded atmel_mxt_ts "Should be unloaded when screen is blanked"
 }
 
 set_loglevel() {
@@ -131,7 +130,7 @@ check_clkctrl() {
 	if [ "${devmem}" != "" ]; then
 		val=$("${devmem}" "${address}")
 	elif [ "${rwmem}" != "" ]; then
-		val=$("${rwmem}" "${address}" | cut -d' ' -f3)
+		val=$("${rwmem}" "${address}" | cut -d' ' -f4)
 	else
 		return
 	fi

--- a/usr/share/droid4-powermanagement/display-state-pm.sh
+++ b/usr/share/droid4-powermanagement/display-state-pm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $5 == "on" ]
+then
+        echo 20000 >  /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/autosuspend_delay_ms
+        printf 'U1234AT+SCRN=1\r' > /dev/gsmtty1
+else
+        echo 100 > /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/autosuspend_delay_ms
+        printf 'U1234AT+SCRN=0\r' > /dev/gsmtty1
+        # hack to workaround idle bug
+        head -c 0 /dev/ttyUSB{3,4}
+fi

--- a/usr/share/droid4-powermanagement/display-state-pm.sh
+++ b/usr/share/droid4-powermanagement/display-state-pm.sh
@@ -3,10 +3,10 @@
 if [ $5 == "on" ]
 then
         echo 20000 >  /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/autosuspend_delay_ms
+        echo on > /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/control
+        echo auto > /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/control
         printf 'U1234AT+SCRN=1\r' > /dev/gsmtty1
 else
         echo 100 > /sys/bus/i2c/drivers/atmel_mxt_ts/1-004a/power/autosuspend_delay_ms
         printf 'U1234AT+SCRN=0\r' > /dev/gsmtty1
-        # hack to workaround idle bug
-        head -c 0 /dev/ttyUSB{3,4}
 fi


### PR DESCRIPTION
Disable modem RSSI reporting while the display is off